### PR TITLE
Parabolic inflow + refactoring

### DIFF
--- a/firecrest/app/firecrest_application.py
+++ b/firecrest/app/firecrest_application.py
@@ -87,9 +87,10 @@ class FirecrestApp:
             logger=logger,
             model_factory=model_factory,
         )
-        result = optimizer.run(
-            self.control_space_configuration["control_default"],
-            self.control_space_configuration["bounds"],
+        optimizer.run(
+            run_mode=self.run_mode,
+            initial_guess=self.control_space_configuration["control_default"],
+            bounds=self.control_space_configuration["bounds"],
             signal_window=self.control_space_configuration["window"],
             optimization_method=self.control_space_configuration["algorithm"],
         )

--- a/firecrest/app/firecrest_application.py
+++ b/firecrest/app/firecrest_application.py
@@ -37,8 +37,13 @@ class FirecrestApp:
     def setup_model_factories(self):
         factories = {
             "models": {
-                "surface_model": SurfaceModelFactory(self.setup_data),
-                "inflow_model": InflowModelFactory(),
+                "surface_model": SurfaceModelFactory(
+                    model_data=self.setup_data["nozzle_domain"].copy(),
+                    constants_data=self.setup_data["constants"].copy()
+                ),
+                "inflow_model": InflowModelFactory(
+                    parameters=self.setup_data.get("inflow_model", {}).copy(),
+                ),
             },
             "solvers": {"unsteady_solver": None},
             "loggers": {

--- a/firecrest/app/firecrest_application.py
+++ b/firecrest/app/firecrest_application.py
@@ -39,10 +39,10 @@ class FirecrestApp:
             "models": {
                 "surface_model": SurfaceModelFactory(
                     model_data=self.setup_data["nozzle_domain"].copy(),
-                    constants_data=self.setup_data["constants"].copy()
+                    constants_data=self.setup_data["constants"].copy(),
                 ),
                 "inflow_model": InflowModelFactory(
-                    parameters=self.setup_data.get("inflow_model", {}).copy(),
+                    parameters=self.setup_data.get("inflow_model", {}).copy()
                 ),
             },
             "solvers": {"unsteady_solver": None},
@@ -73,6 +73,9 @@ class FirecrestApp:
         )
 
         domain = self.domain_configuration["domain"]
+        control_boundary_type = self.setup_data.get("inflow_model", {}).get(
+            "type", None
+        )
         logger = self.factories["loggers"]["base_logger"].create_basic_logger()
         model_factory = self.factories["models"]
         optimizer = UnsteadyOptimizationSolver(
@@ -86,6 +89,7 @@ class FirecrestApp:
             shared_boundary=self.domain_configuration["shared_boundary"],
             logger=logger,
             model_factory=model_factory,
+            control_boundary_type=control_boundary_type,
         )
         optimizer.run(
             run_mode=self.run_mode,

--- a/firecrest/app/firecrest_application.py
+++ b/firecrest/app/firecrest_application.py
@@ -114,14 +114,6 @@ class FirecrestApp:
             * constants_data["length"]
             / constants_data["viscosity"]
         )
-        # L = constants_data["length"]
-        # c_s = constants_data["sound_speed"]
-        # rho = constants_data["density"]
-        # epsilon = constants_data["Mach"]
-        # gamma_st = constants_data["surface_tension"]
-        # mu = constants_data["viscosity"]
-        # Pr = constants_data["Pr"]
-        # Re = rho * c_s * L / mu
         return constants_data
 
     def _configure_time_domain(self):

--- a/firecrest/fem/tv_acoustic_weakform.py
+++ b/firecrest/fem/tv_acoustic_weakform.py
@@ -208,6 +208,14 @@ class BaseTVAcousticWeakForm(ABC, BaseWeakForm):
         )
         return stress
 
+    def weighted_stress(self, state, boundary, weight_vector_function):
+        stress = self.stress(state[0], state[1])
+        stress = dolf.assemble(
+            dolf.dot(dolf.dot(stress, self.domain.n), weight_vector_function)
+            * self.domain.ds((boundary.surface_index,))
+        )
+        return stress
+
     def heat_flux(self, temperature):
         return (
             dolf.grad(temperature)

--- a/firecrest/models/free_surface_cap.py
+++ b/firecrest/models/free_surface_cap.py
@@ -17,13 +17,11 @@ Constants = namedtuple(
 
 
 class SurfaceModelFactory:
-    def __init__(self, setup_data):
-        model_data = setup_data["nozzle_domain"].copy()
+    def __init__(self, model_data, constants_data):
         self.initial_condition = model_data["initial_curvature"]
         nozzle_domain_length = model_data["length"]
         nozzle_domain_radius = model_data["radius"]
 
-        constants_data = setup_data["constants"]
         L = constants_data["length"]
         c_s = constants_data["sound_speed"]
         rho = constants_data["density"]

--- a/firecrest/models/inflow.py
+++ b/firecrest/models/inflow.py
@@ -1,16 +1,71 @@
+from dolfin import Expression
+
+
 class InflowModelFactory:
     def create_normal_inflow_model(self, history):
         return NormalInflow(history)
 
+    def create_parabolic_inflow_model(self, history, left, right):
+        return ParabolicInflow(history, left=left, right=right)
+
 
 class NormalInflow:
+    _shape_expression_schema = ("0.0", "amplitude")
+
     def __init__(self, control_data):
         self.counter = 1
         self.control_data = control_data
 
+        self._shape_expression = self.generate_shape_expression()
+
+    @staticmethod
+    def generate_shape_expression():
+        return Expression(
+            NormalInflow._shape_expression_schema, degree=2, amplitude=1.0
+        )
+
     def eval(self):
         if self.counter < len(self.control_data):
-            value = (0.0, self.control_data[self.counter])
+            amplitude_value = self.control_data[self.counter]
             self.counter += 1
-            return value
-        return 0.0, 0.0
+        else:
+            amplitude_value = 0.0
+        self._shape_expression.amplitude = amplitude_value
+        return self._shape_expression
+
+
+class ParabolicInflow:
+    _shape_expression_schema = (
+        "0.0",
+        "amplitude*4.0/(A-B)/(A-B)*(x[0]-A)*(B-x[0])",
+    )
+
+    def __init__(self, control_data, left, right):
+        self.counter = 1
+        self.control_data = control_data
+
+        self.left = left
+        self.right = right
+        self._shape_expression = self.generate_shape_expression()
+
+    def generate_shape_expression(self):
+        return Expression(
+            ParabolicInflow._shape_expression_schema,
+            degree=2,
+            A=self.left,
+            B=self.right,
+            amplitude=1.0,
+        )
+
+    def eval(self):
+        """ Evaluate the inflow profile at the current time step
+        (tracked by the counter). This mutates the state of the
+        object: the counter is incremented.
+        """
+        if self.counter < len(self.control_data):
+            amplitude_value = self.control_data[self.counter]
+            self.counter += 1
+        else:
+            amplitude_value = 0.0
+        self._shape_expression.amplitude = amplitude_value
+        return self._shape_expression

--- a/firecrest/models/inflow.py
+++ b/firecrest/models/inflow.py
@@ -16,21 +16,20 @@ class InflowModelFactory:
     def __init__(self, parameters):
         self.parameters = parameters
 
-        self.type = self.parameters.get("type", None)
-        if self.type is None:
-            self.type = self._default_type
-            logger.warning(f"Using default type model: {self.type!r}")
-        elif self.type not in self.supported_types:
+    def create_model(self, model_type=None):
+        if model_type is None:
+            model_type = self._default_type
+            logger.warning(f"Using default type model: {model_type!r}")
+
+        if model_type not in self.supported_types:
             raise ValueError(
-                f"Model type {self.type!r} is not supported. Only "
+                f"Model type {model_type!r} is not supported. Only "
                 f"{self.supported_types} are supported."
             )
 
-    @property
-    def create_model(self):
-        if self.type == UNIFORM_TYPE_LABEL:
+        if model_type == UNIFORM_TYPE_LABEL:
             return self.create_normal_inflow_model
-        elif self.type == PARABOLIC_TYPE_LABEL:
+        elif model_type == PARABOLIC_TYPE_LABEL:
             return self.create_parabolic_inflow_model
 
     def create_normal_inflow_model(self, history):

--- a/firecrest/models/inflow.py
+++ b/firecrest/models/inflow.py
@@ -4,7 +4,7 @@ from dolfin import Expression
 
 logger = logging.getLogger(__name__)
 
-UNIFORM_TYPE_LABEL =  "uniform"
+UNIFORM_TYPE_LABEL = "uniform"
 PARABOLIC_TYPE_LABEL = "parabolic"
 
 
@@ -26,6 +26,7 @@ class InflowModelFactory:
                 f"{self.supported_types} are supported."
             )
 
+    @property
     def create_model(self):
         if self.type == UNIFORM_TYPE_LABEL:
             return self.create_normal_inflow_model

--- a/firecrest/models/tests/test_inflow.py
+++ b/firecrest/models/tests/test_inflow.py
@@ -1,6 +1,11 @@
 from unittest import TestCase
+import numpy as np
 
-from firecrest.models.inflow import InflowModelFactory, NormalInflow
+from firecrest.models.inflow import (
+    InflowModelFactory,
+    NormalInflow,
+    ParabolicInflow,
+)
 
 
 class TestInflowModelFactory(TestCase):
@@ -11,9 +16,31 @@ class TestInflowModelFactory(TestCase):
     def test_normal_inflow(self):
         inflow = NormalInflow(control_data=self.control)
         for i in range(self.length - 1):
-            self.assertTupleEqual(inflow.eval(), (0.0, i + 1))
+            np.testing.assert_equal(
+                inflow.eval()(0.0, 0.0), np.array([0.0, i + 1])
+            )
         for _ in range(100):
-            self.assertTupleEqual(inflow.eval(), (0.0, 0.0))
+            np.testing.assert_equal(
+                inflow.eval()(0.0, 0.0), np.array([0.0, 0.0])
+            )
+
+    def test_parabolic_inflow(self):
+        inflow = ParabolicInflow(control_data=self.control, left=3.0, right=4.0)
+        for i in range(self.length - 1):
+            expression = inflow.eval()
+            np.testing.assert_equal(
+                expression(3.0, 0.0), np.array([0.0, 0.0])
+            )
+            np.testing.assert_equal(
+                expression(4.0, 0.0), np.array([0.0, 0.0])
+            )
+            np.testing.assert_equal(
+                expression(3.5, 0.0), np.array([0.0, i + 1])
+            )
+        for _ in range(100):
+            np.testing.assert_equal(
+                inflow.eval()(0.0, 0.0), np.array([0.0, 0.0])
+            )
 
     def test_factory(self):
         factory = InflowModelFactory()

--- a/firecrest/solvers/unsteady_optimizer.py
+++ b/firecrest/solvers/unsteady_optimizer.py
@@ -198,24 +198,12 @@ class UnsteadyOptimizationSolver(OptimizationMixin, UnsteadyTVAcousticSolver):
         self.time_grid = TimeSeries.from_parameters(
             Decimal("0"), self.timer["T"], self.timer["dt"]
         )
-        # self.time_grid = TimeSeries.from_dict(
-        #     {
-        #         Decimal(k) * Decimal(self.timer["dt"]): 0
-        #         for k in range(int(self.timer["T"] / Decimal(self.timer["dt"])) + 1)
-        #     }
-        # )
         # `midpoint_grid` defines the time grid for the adjoint simulation
         self.midpoint_grid = TimeSeries.from_parameters(
             Decimal("0.5") * Decimal(self.timer["dt"]),
             self.timer["T"] - Decimal("0.5") * Decimal(self.timer["dt"]),
             self.timer["dt"],
         )
-        # self.midpoint_grid = TimeSeries.from_dict(
-        #     {
-        #         Decimal(k + 0.5) * Decimal(self.timer["dt"]): 0
-        #         for k in range(int(self.timer["T"] / Decimal(self.timer["dt"])))
-        #     }
-        # )
         # We define a control space, a PiecewiseLinearBasis in this case
         self.basis = PiecewiseLinearBasis(
             np.array([float(key) for key in self.time_grid.keys()]),

--- a/firecrest/solvers/unsteady_optimizer.py
+++ b/firecrest/solvers/unsteady_optimizer.py
@@ -60,6 +60,7 @@ class UnsteadyOptimizationSolver(OptimizationMixin, UnsteadyTVAcousticSolver):
         super().__init__(*args, **kwargs)
         self.acoustic_initial_state = kwargs["initial_state"]
         self.control_boundary = kwargs.get("control_boundary")
+        self.control_boundary_type = kwargs.get("control_boundary_type")
         self.shared_boundary = kwargs.get("shared_boundary")
 
         self.logger = kwargs.get("logger")
@@ -91,7 +92,10 @@ class UnsteadyOptimizationSolver(OptimizationMixin, UnsteadyTVAcousticSolver):
         return data
 
     def initialize_control_boundary(self, control_data):
-        inflow = self.model_factory["inflow_model"].create_model(control_data)
+        inflow_model = self.model_factory["inflow_model"].create_model(
+            model_type=self.control_boundary_type
+        )
+        inflow = inflow_model(control_data)
         self.control_boundary.bcond["inflow"] = inflow
 
     def initialize_shared_boundary(self):

--- a/firecrest/solvers/unsteady_optimizer.py
+++ b/firecrest/solvers/unsteady_optimizer.py
@@ -91,8 +91,8 @@ class UnsteadyOptimizationSolver(OptimizationMixin, UnsteadyTVAcousticSolver):
         return data
 
     def initialize_control_boundary(self, control_data):
-        inflow = self.model_factory["inflow_model"].create_model
-        self.control_boundary.bcond["inflow"] = inflow(control_data)
+        inflow = self.model_factory["inflow_model"].create_model(control_data)
+        self.control_boundary.bcond["inflow"] = inflow
 
     def initialize_shared_boundary(self):
         surface_model = self.model_factory["surface_model"].create_direct_model()

--- a/firecrest/solvers/unsteady_optimizer.py
+++ b/firecrest/solvers/unsteady_optimizer.py
@@ -111,7 +111,11 @@ class UnsteadyOptimizationSolver(OptimizationMixin, UnsteadyTVAcousticSolver):
         return adjoint_surface
 
     def evaluate_adjoint_sensitivity(self, adjoint_state):
-        return self.forms.avg_normal_stress(adjoint_state, self.control_boundary)
+        boundary_model = self.control_boundary.bcond["inflow"]
+        weight_function = boundary_model.generate_shape_expression()
+        return self.forms.weighted_stress(
+            adjoint_state, self.control_boundary, weight_vector_function=weight_function
+        )
 
     @post
     @discrete_to_continuous_direct

--- a/firecrest/solvers/unsteady_optimizer.py
+++ b/firecrest/solvers/unsteady_optimizer.py
@@ -183,11 +183,13 @@ class UnsteadyOptimizationSolver(OptimizationMixin, UnsteadyTVAcousticSolver):
 
     def run(
         self,
+        run_mode,
         initial_guess=None,
         bounds=None,
         signal_window=None,
         optimization_method=None,
     ):
+        self.logger.run_mode = run_mode
         # 1. define control
         # `time_grid` defines the time grid for the direct simulation
         self.time_grid = TimeSeries.from_parameters(
@@ -229,15 +231,15 @@ class UnsteadyOptimizationSolver(OptimizationMixin, UnsteadyTVAcousticSolver):
         if initial_guess is None:
             initial_guess = np.zeros(len(self.basis.basis))
 
-        if self.logger.run_mode == "optimization":
+        if run_mode == "optimization":
             res = self.minimize(
                 initial_guess, bounds, optimization_method=optimization_method
             )
-        elif self.logger.run_mode == "single_run":
+        elif run_mode == "single_run":
             res = self._objective_state(initial_guess)
             grad = self._jacobian(res)
         else:
-            log.warn(f"The runtime {self.logger.run_mode} is not implemented")
+            log.warning(f"The run mode {run_mode} is not implemented")
             res = None
 
         return res

--- a/firecrest/solvers/unsteady_optimizer.py
+++ b/firecrest/solvers/unsteady_optimizer.py
@@ -92,11 +92,10 @@ class UnsteadyOptimizationSolver(OptimizationMixin, UnsteadyTVAcousticSolver):
         return data
 
     def initialize_control_boundary(self, control_data):
-        inflow_model = self.model_factory["inflow_model"].create_model(
+        inflow = self.model_factory["inflow_model"].create_model(
             model_type=self.control_boundary_type
         )
-        inflow = inflow_model(control_data)
-        self.control_boundary.bcond["inflow"] = inflow
+        self.control_boundary.bcond["inflow"] = inflow(control_data)
 
     def initialize_shared_boundary(self):
         surface_model = self.model_factory["surface_model"].create_direct_model()

--- a/firecrest/solvers/unsteady_optimizer.py
+++ b/firecrest/solvers/unsteady_optimizer.py
@@ -91,7 +91,7 @@ class UnsteadyOptimizationSolver(OptimizationMixin, UnsteadyTVAcousticSolver):
         return data
 
     def initialize_control_boundary(self, control_data):
-        inflow = self.model_factory["inflow_model"].create_normal_inflow_model
+        inflow = self.model_factory["inflow_model"].create_model
         self.control_boundary.bcond["inflow"] = inflow(control_data)
 
     def initialize_shared_boundary(self):


### PR DESCRIPTION
### Changes

#### Factory changes

- `SurfaceModelFactory` now accepts explicit `model_data` and `constants` arguments, instead of parsing the `setup_data` dict
- Created new `InflowModelFactory` that generates inflow models


#### `UnsteadyOptimizationSolver` changes

- `UnsteadyOptimizationSolver` now accepts a `control_boundary_type` argument instead of assuming a uniform velocity profile on the inflow boundary (fix this later)
- `UnsteadyOptimizationSolver.run` method now uses a mandatory `run_mode` argument for the run mode, instead of inferring that from the logger configuration
- `evaluate_adjoint_sensitivity` method now uses the velocity shape to evaluate the adjoint sensitivity


#### Inflow model changes

- Reworked the `NormalInflow`
- Added `ParabolicInflow`


#### Weak form changes

- Added new `weighted_stress` method to the acoustic weak form that calculates a weighted (not just average) stress along the boundary

