### PR TITLE
Refinement option for SimpleDomain

### DIFF
--- a/firecrest/mesh/boundaryelement.py
+++ b/firecrest/mesh/boundaryelement.py
@@ -106,8 +106,14 @@ class BSplineElement(BoundaryElement):
         super().__init__(control_points, bcond=bcond, el_size=el_size, **kwargs)
         self.spline_degree = kwargs.pop("degree", 3)
         self.spline_periodic = kwargs.pop("periodic", False)
-        self.n = self.estimate_points_number(self.control_points, self.el_size)
         self.kwargs = kwargs
+
+        # Do not specify extra points for lines: control points themselves
+        # are enough
+        if self.spline_degree == 1:
+            self.n = len(self.control_points) - 1
+        else:
+            self.n = self.estimate_points_number(self.control_points, self.el_size)
 
         self.control_points = control_points
 

--- a/firecrest/mesh/geometry.py
+++ b/firecrest/mesh/geometry.py
@@ -297,6 +297,7 @@ class SimpleDomain(Geometry):
         mesh_name="mesh",
         mesh_folder="Mesh",
         dimensions=2,
+        refinement_level=0,
         **kwargs
     ):
         super().__init__(
@@ -305,6 +306,18 @@ class SimpleDomain(Geometry):
         self._generate_pg_geometry()
         self.compile_mesh()
         self.mesh = self.load_mesh()
+
+        if refinement_level > 0:
+            dolf.parameters["refinement_algorithm"] = "plaza_with_parent_facets"
+            for _ in range(refinement_level):
+                cf = dolf.MeshFunction("bool", self.mesh, True)
+                cf.set_all(True)
+                self.mesh = dolf.refine(self.mesh, cf)
+                self._boundary_parts = dolf.adapt(self.boundary_parts, self.mesh)
+            print(
+                f"Refinement level: {refinement_level}, "
+                f"nof cells: {len(list(dolf.cells(self.mesh)))}"
+            )
 
     def _generate_surface_points(self):
         """

--- a/firecrest/mesh/geometry.py
+++ b/firecrest/mesh/geometry.py
@@ -1,15 +1,14 @@
+import logging
 import os
 import pygmsh as pg
 import meshio
-import numpy as np
 import subprocess
 import warnings
-from abc import ABC, abstractmethod
+from abc import ABC
 import dolfin as dolf
 from dolfin_utils.meshconvert import meshconvert
 
-# from dolfin_utils.meshconvert import meshconvert
-# import dolfin as dolf
+logger = logging.getLogger(__name__)
 
 GEO_EXT = ".geo"
 MSH_EXT = ".msh"
@@ -314,7 +313,7 @@ class SimpleDomain(Geometry):
                 cf.set_all(True)
                 self.mesh = dolf.refine(self.mesh, cf)
                 self._boundary_parts = dolf.adapt(self.boundary_parts, self.mesh)
-            print(
+            logging.info(
                 f"Refinement level: {refinement_level}, "
                 f"nof cells: {len(list(dolf.cells(self.mesh)))}"
             )


### PR DESCRIPTION
`SimpleDomain` now accepts a `refinement_level: int` argument to refine the whole domain several times.

Also, minor fixes:
- The `LineElement`s will not have redundant boundary points generated automatically (points between the control points)