### PR TITLE
Minor improvements

### DIFF
--- a/firecrest/app/firecrest_application.py
+++ b/firecrest/app/firecrest_application.py
@@ -91,7 +91,7 @@ class FirecrestApp:
             model_factory=model_factory,
             control_boundary_type=control_boundary_type,
         )
-        optimizer.run(
+        return optimizer, optimizer.run(
             run_mode=self.run_mode,
             initial_guess=self.control_space_configuration["control_default"],
             bounds=self.control_space_configuration["bounds"],

--- a/firecrest/solvers/unsteady_optimizer.py
+++ b/firecrest/solvers/unsteady_optimizer.py
@@ -125,6 +125,7 @@ class UnsteadyOptimizationSolver(OptimizationMixin, UnsteadyTVAcousticSolver):
     def _objective_state(self, control):
         self.initialize_control_boundary(control)
 
+        state = None
         surface_model = self.initialize_shared_boundary()
         _old_flow_rate = 0
         for state in self.solve_direct(
@@ -227,6 +228,8 @@ class UnsteadyOptimizationSolver(OptimizationMixin, UnsteadyTVAcousticSolver):
                 initial_guess, bounds, optimization_method=optimization_method
             )
         elif run_mode == "single_run":
+            res = self._objective_state(initial_guess)
+        elif run_mode == "direct_adjoint":
             res = self._objective_state(initial_guess)
             grad = self._jacobian(res)
         else:


### PR DESCRIPTION
- `FirecrestApp.run` now returns the optimizer and the result of the optimizer run.
- `UnsteadyOptimizer`: `"single_run"` mode only runs the direct computation, `"direct_adjoint"` runs both direct and adjoint